### PR TITLE
rajeeja/remove_numpy_pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - matplotlib-inline
     - netcdf4
     - numba
-    - numpy <2.3
+    - numpy
     - pandas
     - python >={{ python_min }}
     - scikit-learn


### PR DESCRIPTION

- remove the numpy upper bound from recipe/meta.yaml
